### PR TITLE
Use PBKDF2 key derivation for crypto password

### DIFF
--- a/lib/Crypt.py
+++ b/lib/Crypt.py
@@ -66,7 +66,7 @@ class CryptString:
         cipher = AES.new(key_enc, AES.MODE_CBC, iv)
 
         ctext = cipher.encrypt(pad(string))
-        mac.update(ctext + iv + self.secret)
+        mac.update(ctext + iv)
         auth = mac.digest()
         return base64.b64encode(iv + auth + ctext)
 
@@ -82,7 +82,7 @@ class CryptString:
         cipher = AES.new(key_enc, AES.MODE_CBC, iv)
         mac = HMAC.new(key_auth, digestmod=SHA256.new())
 
-        mac.update(ctext + iv + self.secret)
+        mac.update(ctext + iv)
         auth_c = mac.digest()
         if auth_c != auth:
             return None


### PR DESCRIPTION
The random IV is reused for the salt. This means the encryption key
won't be static anymore and changes for every message. It also makes
brute-forcing harder.

(All these changes are mostly an excercise for me on how to implement a good cryptosystem, according to best practices. Still, I hope they may be useful!)
